### PR TITLE
Behavior keys re-ordering, additions, corrections

### DIFF
--- a/behaviors/behavior-keys.md
+++ b/behaviors/behavior-keys.md
@@ -53,5 +53,5 @@ Dynamically populated structs should be assigned the `any` type.
 Data type fields must be the same across behaviors. For instance if field **foo** in behavior A has type: number, field **foo** \(assuming its the same field\) in behavior B must have type: number.
 
 {% hint style="info" %}
-Field Names at the top level of your keys cannot match built-in fields \(e.g. `agent_id`, `position`\) and cannot start with double-underscore \(e.g. `__age`\), which are reserved for engine specific information. Structs below the top level (i.e. under another field) may contain these fields.
+Field Names at the top level of your keys cannot match built-in fields \(e.g. `agent_id`, `position`\) and cannot start with double-underscore \(e.g. `__age`\), which are reserved for engine specific information. Fields below the top level (i.e. as a child of a top-level field) may match those names.
 {% endhint %}

--- a/behaviors/behavior-keys.md
+++ b/behaviors/behavior-keys.md
@@ -20,7 +20,7 @@ From the behavior key panel you can define the field the behavior will need to a
 
 ### How do I know what fields I need to assign?
 
-Any fields your behavior is getting from state, or setting in state, should have an entry in your behavior keys. For example, if your behavior calls `state.set("name", "Bob")`, you should have a behavior key called `name` with type `string`.
+Any custom fields your behavior is getting from state, or setting in state, should have an entry in your behavior keys. For example, if your behavior calls `state.set("cost", 300)`, you should have a behavior key called `cost` with type `number`. You do not need to create entries for special fields which HASH defines - see 'builtin fields' below.
 
 ### Types
 
@@ -28,11 +28,11 @@ If you've used a statically defined language before - like Rust, Go, or Clojure 
 
 Types:
 
-| Type | Example |
+| Type | Example(s) |
 | :--- | :--- |
 | Strings | "Hello" |
 | Booleans | True |
-| Numbers \(floats\) | 4.00 |
+| Numbers | 4.00 |
 | Structs \(objects with typed fields\) | {"foo": "bar"} |
 | Arrays \(ordered collections containing the same type\) | \[1,2,3\] |
 | Fixed-size Arrays | \[1,2,3\] \(max 3 elements\)  |
@@ -52,6 +52,23 @@ Dynamically populated structs should be assigned the `any` type.
 
 Data type fields must be the same across behaviors. For instance if field **foo** in behavior A has type: number, field **foo** \(assuming its the same field\) in behavior B must have type: number.
 
+### Built-in fields
 {% hint style="info" %}
 Field Names at the top level of your keys cannot match built-in fields \(e.g. `agent_id`, `position`\) and cannot start with double-underscore \(e.g. `__age`\), which are reserved for engine specific information. Fields below the top level (i.e. as a child of a top-level field) may match those names.
 {% endhint %}
+
+You do not need to define these in your behavior keys.
+- agent_id
+- agent_name
+- behaviors
+- color
+- direction
+- height
+- hidden
+- messages
+- position
+- position_was_corrected
+- rgb
+- scale
+- search_radius
+- shape

--- a/behaviors/behavior-keys.md
+++ b/behaviors/behavior-keys.md
@@ -20,7 +20,7 @@ From the behavior key panel you can define the field the behavior will need to a
 
 ### How do I know what fields I need to assign?
 
-Any custom fields your behavior is getting from state, or setting in state, should have an entry in your behavior keys. For example, if your behavior calls `state.set("cost", 300)`, you should have a behavior key called `cost` with type `number`. You do not need to create entries for special fields which HASH defines - see 'builtin fields' below.
+Any custom fields your behavior is getting from state, or setting in state, should have an entry in your behavior keys. For example, if your behavior calls `state.set("cost", 300)`, you should have a behavior key called `cost` with type `number`. You do not need to create entries for special fields which HASH defines - see 'Built-in Fields' below.
 
 ### Types
 
@@ -28,7 +28,7 @@ If you've used a statically defined language before - like Rust, Go, or Clojure 
 
 Types:
 
-| Type | Example(s) |
+| Type | Example |
 | :--- | :--- |
 | Strings | "Hello" |
 | Booleans | True |

--- a/behaviors/behavior-keys.md
+++ b/behaviors/behavior-keys.md
@@ -8,7 +8,23 @@ Behavior Keys define the **data** **type** of the fields that a behavior accesse
 Behavior Keys are **optional** for in-browser simulation runs, but are **required** for cloud runs.
 {% endhint %}
 
-If you've used a statically defined language before - like Rust, Go, or Clojure then you'll already be familiar with strong type systems. You select the type - `string`, `number`, `list`, etc. - of data that a field will store. This improves memory allocation and access speed, as well as making sure that if you assign an incorrect type to the field an error is thrown.
+### Accessing Behavior Keys
+
+To view the behavior keys associated with a file, click the button containing the _brain_ icon, located beneath the help button, to toggle the key panel's visibility.
+
+### Assigning Behavior Keys
+
+From the behavior key panel you can define the field the behavior will need to access by putting in the name of the field - the same name as its field name on the agents state object - and the type of the field.
+
+![Click the brain icon to toggle the behavior key panel&apos;s visibility](../.gitbook/assets/screen-shot-2020-11-24-at-5.34.20-pm.png)
+
+### How do I know what fields I need to assign?
+
+Any fields your behavior is getting from state, or setting in state, should have an entry in your behavior keys. For example, if your behavior calls `state.set("name", "Bob")`, you should have a behavior key called `name` with type `string`.
+
+### Types
+
+If you've used a statically defined language before - like Rust, Go, or Clojure then you'll already be familiar with strong type systems. You select the type - `string`, `number`, `list`, etc. - of data that a field will store. This improves memory allocation and access speed, as well as making sure that if you assign an incorrect type to the field an error is thrown.  **If you are unsure about typing a field, assign it an 'any' type - or ask us for help!**
 
 Types:
 
@@ -26,17 +42,7 @@ The `any` type designation can apply, appropriately enough, to any data type - i
 
 All fields are nullable \(which means they can be assigned a null value, or may exist with no value assigned\) by default. You can turn off nullability, making a field non-nullable, which will improve simulation performance and memory utilization further.
 
-### Accessing Behavior Keys
-
-To view the behavior keys associated with a file, click the button containing the _brain_ icon, located beneath the help button, to toggle the key panel's visibility.
-
-### Assigning Behavior Keys
-
-From the behavior key panel you can define the field the behavior will need to access by putting in the name of the field - the same name as its field name on the agents state object - and the type of the field.
-
-![Click the brain icon to toggle the behavior key panel&apos;s visibility](../.gitbook/assets/screen-shot-2020-11-24-at-5.34.20-pm.png)
-
-For complex data types - lists, fixed sized lists, and structs, click the tree icon to assign the data types of members of the list or struct.
+For complex data types - lists, fixed sized lists, and structs, **you must click the tree icon** to assign the data types of members of the list or struct.
 
 {% hint style="info" %}
 Dynamically populated structs should be assigned the `any` type.
@@ -47,6 +53,5 @@ Dynamically populated structs should be assigned the `any` type.
 Data type fields must be the same across behaviors. For instance if field **foo** in behavior A has type: number, field **foo** \(assuming its the same field\) in behavior B must have type: number.
 
 {% hint style="info" %}
-Field Names cannot match built-in fields \(e.g. `agentid`, `position`\) and cannot start with double-underscore \(e.g. `__age`\), which are reserved for engine specific information. 
+Field Names at the top level of your keys cannot match built-in fields \(e.g. `agent_id`, `position`\) and cannot start with double-underscore \(e.g. `__age`\), which are reserved for engine specific information. Structs below the top level (i.e. under another field) may contain these fields.
 {% endhint %}
-


### PR DESCRIPTION
Defining behavior keys is one of the more technical things we ask of users, and I'm suggesting a few changes to the docs:

1. Reorder the page to move information on specific types below the higher-level stuff.
2. Add a section on how a user would determine what they need to define
3. Remove reference to 'float' in numbers
4. Say that they can assign things as 'any' if they get stuck
5. Tweak the section on built-ins a little. It's actually `agent_id` rather than `agentid`
6. Added full list of built-in fields to end