### PR TITLE
[DOCS] Standardized how we show code blocks on plots-syntax-reference

### DIFF
--- a/views/analysis/plots-syntax-reference.md
+++ b/views/analysis/plots-syntax-reference.md
@@ -6,7 +6,7 @@
 
 {% tabs %}
 {% tab title="Code" %}
-```text
+```javascript
 {
   "title": "My histogram",
   "type": "histogram",
@@ -26,7 +26,7 @@
 
 {% tabs %}
 {% tab title="Code" %}
-```text
+```javascript
 {
   "title": "My horizontal histogram",
   "type": "histogram",
@@ -46,7 +46,7 @@
 
 {% tabs %}
 {% tab title="Code" %}
-```text
+```javascript
 {
   "title": "Two histograms on the same plot",
   "type": "histogram",
@@ -66,7 +66,7 @@
 
 {% tabs %}
 {% tab title="Code" %}
-```text
+```javascript
 {
   "title": "Two horizontal histograms on the same plot",
   "type": "histogram",
@@ -214,6 +214,3 @@
 ![](../../.gitbook/assets/screenshot-2021-03-11-at-15.15.03.png)
 {% endtab %}
 {% endtabs %}
-
-
-


### PR DESCRIPTION
## What does this change? 

Fixes the https://docs.hash.ai/core/views/analysis/plots-syntax-reference page

## Before some items were looking like this
![Screenshot 2021-03-12 at 14 53 05](https://user-images.githubusercontent.com/698649/110949338-c7513400-8342-11eb-9b9d-4c7271dbadb6.png)

## When they should look like this
![Screenshot 2021-03-12 at 14 53 09](https://user-images.githubusercontent.com/698649/110949345-c8826100-8342-11eb-8c62-2f0a7c484ce7.png)
